### PR TITLE
[conda-bld] chdir to install location, since nosetests operates on dirs

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: bhmm-dev
-  version: !!str 0.0.0
+  version: !!str 0.1.0
 
 build:
   preserve_egg_dir: True
@@ -38,8 +38,6 @@ test:
     - nose
   imports:
     - bhmm
-  commands:
-    - nosetests bhmm --nocapture --verbosity=2 --with-doctest
 
 about:
   home: https://github.com/choderalab/bhmm

--- a/devtools/conda-recipe/run_test.py
+++ b/devtools/conda-recipe/run_test.py
@@ -1,0 +1,12 @@
+import os
+import nose
+import bhmm
+
+
+path = bhmm.__path__[0]
+path = os.path.join(path, '..')
+print ("executing nose from new path:", path)
+
+os.chdir(path)
+args = ['bhmm', '--nocapture', '--verbosity=2', '--with-doctest']
+nose.main(args)


### PR DESCRIPTION
This fixes the ImportError which showed up in #18.  The background of this is, that nosetests either expects a file or a directory to search for test units, but during conda-build the command gets executed in the wrong place. Since one can not reproduce #18 in normal environments (eg. python shell) this is cleary a nose issue.

The fix is to chdir relative to the test installation, so nose can find the desired directory.
