### PR TITLE
changed all relative imports to absolute imports

### DIFF
--- a/bhmm/__init__.py
+++ b/bhmm/__init__.py
@@ -10,7 +10,7 @@ import version as _version
 __version__ = _version.version
 
 # import API
-from api import *
+from bhmm.api import *
 
 # hmms
 from bhmm.hmm.generic_hmm import HMM
@@ -26,8 +26,8 @@ from bhmm.estimators.bayesian_sampling import BayesianHMMSampler as BHMM
 from bhmm.estimators.maximum_likelihood import MaximumLikelihoodEstimator as MLHMM
 
 # output models
-from output_models import OutputModel, GaussianOutputModel, DiscreteOutputModel
+from bhmm.output_models import OutputModel, GaussianOutputModel, DiscreteOutputModel
 
 # other stuff
-from util import config
-from util import testsystems
+from bhmm.util import config
+from bhmm.util import testsystems

--- a/bhmm/api.py
+++ b/bhmm/api.py
@@ -2,10 +2,10 @@ __author__ = 'noe'
 
 import numpy as _np
 
-from util import types as _types
-from hmm.generic_hmm import HMM as _HMM
-from estimators.maximum_likelihood import MaximumLikelihoodEstimator as _MaximumLikelihoodEstimator
-from estimators.bayesian_sampling import BayesianHMMSampler as _BHMM
+from bhmm.util import types as _types
+from bhmm.hmm.generic_hmm import HMM as _HMM
+from bhmm.estimators.maximum_likelihood import MaximumLikelihoodEstimator as _MaximumLikelihoodEstimator
+from bhmm.estimators.bayesian_sampling import BayesianHMMSampler as _BHMM
 
 def _guess_model_type(observations):
     o1 = _np.array(observations[0])
@@ -102,8 +102,8 @@ def gaussian_hmm(P, means, sigmas, pi=None, stationary=True, reversible=True):
         If True: transition matrix will fulfill detailed balance constraints.
 
     """
-    from hmm.gaussian_hmm import GaussianHMM
-    from output_models.gaussian import GaussianOutputModel
+    from bhmm.hmm.gaussian_hmm import GaussianHMM
+    from bhmm.output_models.gaussian import GaussianOutputModel
     # count states
     nstates = _np.array(P).shape[0]
     # initialize output model
@@ -131,8 +131,8 @@ def discrete_hmm(P, pout, pi=None, stationary=True, reversible=True):
         If True: transition matrix will fulfill detailed balance constraints.
 
     """
-    from hmm.discrete_hmm import DiscreteHMM
-    from output_models.discrete import DiscreteOutputModel
+    from bhmm.hmm.discrete_hmm import DiscreteHMM
+    from bhmm.output_models.discrete import DiscreteOutputModel
     # initialize output model
     output_model = DiscreteOutputModel(pout)
     # initialize general HMM

--- a/bhmm/hidden/__init__.py
+++ b/bhmm/hidden/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'noe'
 
-from api import *
+from bhmm.hidden.api import *

--- a/bhmm/hidden/api.py
+++ b/bhmm/hidden/api.py
@@ -9,8 +9,8 @@ kernels. All implementations are based on paper Rabiners [1].
 """
 import numpy as np
 
-import impl_python as ip
-import impl_c as ic
+from bhmm.hidden import impl_python as ip
+from bhmm.hidden import impl_c as ic
 from bhmm.util import config
 
 

--- a/bhmm/hidden/impl_c/__init__.py
+++ b/bhmm/hidden/impl_c/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'noe'
 
-from .hidden import *
+from bhmm.hidden.impl_c.hidden import *

--- a/bhmm/hidden/impl_python/__init__.py
+++ b/bhmm/hidden/impl_python/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'noe'
 
-from hidden import *
+from bhmm.hidden.impl_python.hidden import *

--- a/bhmm/hmm/discrete_hmm.py
+++ b/bhmm/hmm/discrete_hmm.py
@@ -2,8 +2,8 @@ __author__ = 'noe'
 
 import numpy as np
 
-from generic_hmm import HMM
-from generic_sampled_hmm import SampledHMM
+from bhmm.hmm.generic_hmm import HMM
+from bhmm.hmm.generic_sampled_hmm import SampledHMM
 from bhmm.output_models.discrete import DiscreteOutputModel
 from bhmm.util import config
 from bhmm.util.statistics import confidence_interval_arr

--- a/bhmm/hmm/gaussian_hmm.py
+++ b/bhmm/hmm/gaussian_hmm.py
@@ -10,10 +10,11 @@ __license__ = "LGPL"
 __maintainer__ = "John D. Chodera"
 __email__="jchodera AT gmail DOT com"
 
-from generic_hmm import HMM
-from generic_sampled_hmm import SampledHMM
-from bhmm.output_models.gaussian import GaussianOutputModel
 import numpy as np
+
+from bhmm.hmm.generic_hmm import HMM
+from bhmm.hmm.generic_sampled_hmm import SampledHMM
+from bhmm.output_models.gaussian import GaussianOutputModel
 from bhmm.util import config
 from bhmm.util.statistics import confidence_interval_arr
 

--- a/bhmm/hmm/generic_sampled_hmm.py
+++ b/bhmm/hmm/generic_sampled_hmm.py
@@ -11,7 +11,8 @@ __maintainer__ = "John D. Chodera"
 __email__="jchodera AT gmail DOT com"
 
 import numpy as np
-from generic_hmm import HMM
+
+from bhmm.hmm.generic_hmm import HMM
 from bhmm.util import config
 from bhmm.util.statistics import confidence_interval_arr
 

--- a/bhmm/msm/transition_matrix_sampling_rev.py
+++ b/bhmm/msm/transition_matrix_sampling_rev.py
@@ -2,7 +2,8 @@ __author__ = 'noe'
 
 import numpy as np
 import math
-import linalg
+
+from bhmm.msm import linalg
 
 __author__ = "Hao Wu, Frank Noe"
 __copyright__ = "Copyright 2015, John D. Chodera and Frank Noe"

--- a/bhmm/output_models/__init__.py
+++ b/bhmm/output_models/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'noe'
 
-from outputmodel import OutputModel
-from discrete import DiscreteOutputModel
-from gaussian import GaussianOutputModel
+from bhmm.output_models.outputmodel import OutputModel
+from bhmm.output_models.discrete import DiscreteOutputModel
+from bhmm.output_models.gaussian import GaussianOutputModel

--- a/bhmm/output_models/gaussian.py
+++ b/bhmm/output_models/gaussian.py
@@ -7,7 +7,7 @@ __email__="jchodera AT gmail DOT com, frank DOT noe AT fu-berlin DOT de"
 
 import numpy as np
 
-import impl_c.gaussian as gc
+from bhmm.output_models.impl_c import gaussian as gc
 from bhmm.output_models import OutputModel
 from bhmm.util.logger import logger
 from bhmm.util import config

--- a/bhmm/tests/test_hidden.py
+++ b/bhmm/tests/test_hidden.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 import time
 
-import bhmm.hidden as hidden
+from bhmm import hidden
 from bhmm.output_models.gaussian import GaussianOutputModel
 
 print_speedup = False

--- a/bhmm/util/statistics.py
+++ b/bhmm/util/statistics.py
@@ -32,7 +32,7 @@ Created on Jul 25, 2014
 import numpy as np
 import math
 import itertools
-import types
+from bhmm.util import types
 
 def confidence_interval(data, alpha):
     """


### PR DESCRIPTION
Changed all imports to be absolute. However, the same problem persists.

I can execute the nosetests as follows without any error:

```
nosetests bhmm --nocapture --verbosity=2 --with-doctest
```

But the following test run raises lots of import errors that make no sense to me,

```
conda build devtools/conda-recipe/
```

including:

```
/bhmm/api.py", line 6, in <module>
    from bhmm.hmm.generic_hmm import HMM as _HMM
ImportError: No module named hmm.generic_hmm
```

No idea what the problem is, because I can use the bhmm package from python or ipython without problems... Any ideas?
