### PR TITLE
Fix discrete init

### DIFF
--- a/bhmm/__init__.py
+++ b/bhmm/__init__.py
@@ -18,8 +18,8 @@ from bhmm.hmm.gaussian_hmm import GaussianHMM
 from bhmm.hmm.discrete_hmm import DiscreteHMM
 
 from bhmm.hmm.generic_sampled_hmm import SampledHMM
-#from bhmm.hmm.gaussian_hmm import SampledGaussianHMM
-#from bhmm.hmm.discrete_hmm import SampledDiscreteHMM
+from bhmm.hmm.gaussian_hmm import SampledGaussianHMM
+from bhmm.hmm.discrete_hmm import SampledDiscreteHMM
 
 # estimators
 from bhmm.estimators.bayesian_sampling import BayesianHMMSampler as BHMM

--- a/bhmm/__init__.py
+++ b/bhmm/__init__.py
@@ -14,8 +14,8 @@ from bhmm.api import *
 
 # hmms
 from bhmm.hmm.generic_hmm import HMM
-#from bhmm.hmm.gaussian_hmm import GaussianHMM
-#from bhmm.hmm.discrete_hmm import DiscreteHMM
+from bhmm.hmm.gaussian_hmm import GaussianHMM
+from bhmm.hmm.discrete_hmm import DiscreteHMM
 
 from bhmm.hmm.generic_sampled_hmm import SampledHMM
 #from bhmm.hmm.gaussian_hmm import SampledGaussianHMM

--- a/bhmm/estimators/maximum_likelihood.py
+++ b/bhmm/estimators/maximum_likelihood.py
@@ -100,8 +100,8 @@ class MaximumLikelihoodEstimator(object):
                 logger().warn('Requested reversible='+str(reversible)+' but initial model is reversible='+
                               str(self._hmm.is_reversible)+'. Using reversible='+str(self._hmm.is_reversible))
             # setting parameters
-            self._reversible = self._hmm.reversible
-            self._stationary = self._hmm.stationary
+            self._reversible = self._hmm.is_reversible
+            self._stationary = self._hmm.is_stationary
         else:
             # Generate our own initial model.
             self._hmm = bhmm.init_hmm(observations, nstates, type=type)

--- a/bhmm/hmm/generic_hmm.py
+++ b/bhmm/hmm/generic_hmm.py
@@ -120,10 +120,15 @@ class HMM(object):
             self._spectral_decomp_available = False
 
     def __repr__(self):
+        from bhmm.output_models import OutputModel
+        if issubclass(self.__class__, OutputModel):
+            outrepr = repr(OutputModel.__repr__(self))
+        else:
+            outrepr = repr(self.output_model)
         """ Returns a string representation of the HMM """
         return "HMM(%d, %s, %s, Pi=%s, stationary=%s, reversible=%s)" % (self._nstates,
                                                                          repr(self._Tij),
-                                                                         repr(self.output_model),
+                                                                         outrepr,
                                                                          repr(self._Pi),
                                                                          repr(self._stationary),
                                                                          repr(self._reversible))
@@ -138,7 +143,11 @@ class HMM(object):
         output += 'Pi:\n'
         output += str(self._Pi) + '\n'
         output += 'output model:\n'
-        output += str(self.output_model)
+        from bhmm.output_models import OutputModel
+        if issubclass(self.__class__, OutputModel):
+            output += str(OutputModel.__str__(self))
+        else:
+            output += str(self.output_model)
         output += '\n'
         return output
 

--- a/bhmm/init/discrete.py
+++ b/bhmm/init/discrete.py
@@ -70,6 +70,7 @@ def initial_model_discrete(observations, nstates, lag=1, reversible=True):
 
     # symmetrize and renormalize to eliminate numerical errors
     X = np.dot(np.diag(pcca.coarse_grained_stationary_probability), P_coarse)
+    X = 0.5 * (X + X.T)
     # if there are values < 0, set to eps
     X = np.maximum(X, eps)
     # turn into coarse-grained transition matrix

--- a/bhmm/output_models/discrete.py
+++ b/bhmm/output_models/discrete.py
@@ -58,7 +58,6 @@ class DiscreteOutputModel(OutputModel):
                [ 0.1,  0.9]]))
 
         """
-
         return "DiscreteOutputModel(%s)" % repr(self._output_probabilities)
 
     def __str__(self):

--- a/bhmm/tests/test_init.py
+++ b/bhmm/tests/test_init.py
@@ -16,9 +16,14 @@ class TestHMM(unittest.TestCase):
         dtrajs = [msmgen.generate_traj(P, T)]
         # estimate initial HMM with 2 states - should be identical to P
         hmm = initdisc.initial_model_discrete(dtrajs, 2)
-        # A should be close to P
+        # test
         A = hmm.transition_matrix
         B = hmm.output_model.output_probabilities
+        # Test stochasticity
+        import pyemma.msm.analysis as msmana
+        msmana.is_transition_matrix(A)
+        np.allclose(B.sum(axis=1), np.ones(B.shape[0]))
+        # A should be close to P
         if (B[0,0]<B[1,0]):
             B = B[np.array([1,0]),:]
         assert(np.max(A-P) < 0.01)
@@ -37,10 +42,14 @@ class TestHMM(unittest.TestCase):
         dtrajs = [msmgen.generate_traj(P, T)]
         # estimate initial HMM with 2 states - should be identical to P
         hmm = initdisc.initial_model_discrete(dtrajs, nstates)
-        # Test if model fit is close to reference.
-        # TODO: Set tolerance to ensure failures are statistically significant.
+        # Test if model fit is close to reference. Note that we do not have an exact reference, so we cannot set the
+        # tolerance in a rigorous way to test statistical significance. These are just sanity checks.
         Tij = hmm.transition_matrix
         B = hmm.output_model.output_probabilities
+        # Test stochasticity
+        import pyemma.msm.analysis as msmana
+        msmana.is_transition_matrix(Tij)
+        np.allclose(B.sum(axis=1), np.ones(B.shape[0]))
         #if (B[0,0]<B[1,0]):
         #    B = B[np.array([1,0]),:]
         Tij_ref = np.array([[0.99, 0.01],
@@ -49,6 +58,30 @@ class TestHMM(unittest.TestCase):
                          [0.0, 0.0, 0.5, 0.5]])
         assert(np.max(Tij-Tij_ref) < 0.01)
         assert(np.max(B-Bref) < 0.05 or np.max(B[[1,0]]-Bref) < 0.05)
+
+    def test_discrete_6_3(self):
+        # 4x4 transition matrix
+        nstates = 3
+        P = np.array([[0.90, 0.10, 0.00, 0.00, 0.00, 0.00],
+                      [0.20, 0.79, 0.01, 0.00, 0.00, 0.00],
+                      [0.00, 0.01, 0.84, 0.15, 0.00, 0.00],
+                      [0.00, 0.00, 0.05, 0.94, 0.01, 0.00],
+                      [0.00, 0.00, 0.00, 0.02, 0.78, 0.20],
+                      [0.00, 0.00, 0.00, 0.00, 0.10, 0.90]])
+        # generate realization
+        import pyemma.msm.generation as msmgen
+        T = 10000
+        dtrajs = [msmgen.generate_traj(P, T)]
+        # estimate initial HMM with 2 states - should be identical to P
+        hmm = initdisc.initial_model_discrete(dtrajs, nstates)
+        # Test stochasticity and reversibility
+        Tij = hmm.transition_matrix
+        B = hmm.output_model.output_probabilities
+        import pyemma.msm.analysis as msmana
+        msmana.is_transition_matrix(Tij)
+        msmana.is_reversible(Tij)
+        np.allclose(B.sum(axis=1), np.ones(B.shape[0]))
+
 
 if __name__=="__main__":
     unittest.main()

--- a/examples/discrete_1d_2min/run.py
+++ b/examples/discrete_1d_2min/run.py
@@ -26,7 +26,7 @@ for (i,lag) in enumerate(lags):
         observations.append(o[shift:][::lag])
 
     # initial HMM
-    hmm = bhmm.estimate_hmm(observations, nstates, output_model_type='discrete')
+    hmm = bhmm.estimate_hmm(observations, nstates, type='discrete')
     its[i] = lag*hmm.timescales
     likelihoods[i] = hmm.likelihood
 

--- a/examples/p5ab-hairpin/generate-figure.py
+++ b/examples/p5ab-hairpin/generate-figure.py
@@ -67,7 +67,7 @@ def run(nstates, nsamples):
 
     # write latex table with sample statistics
     conf = 0.95
-    sampled_hmm = bhmm.SampledGaussianHMM(mle, bhmm_models)
+    sampled_hmm = bhmm.BHMM(mle, bhmm_models)
     generate_latex_table(sampled_hmm, conf=conf, dt=tau, time_unit='s',
                          caption='Bayesian HMM parameter estimates for p5ab hairpin data.',
                          outfile='p5ab-bhmm-statistics-table.tex')

--- a/examples/p5ab-hairpin/generate-figure.py
+++ b/examples/p5ab-hairpin/generate-figure.py
@@ -50,7 +50,7 @@ def run(nstates, nsamples):
 
     # Initialize BHMM, using MLHMM model as initial model.
     print "Initializing BHMM and running with "+str(nsamples)+" samples."
-    sampler = bhmm.BayesianHMMSampler(O, nstates, initial_model=mle)
+    sampler = bhmm.BHMM(O, nstates, initial_model=mle)
 
     # Sample models.
     bhmm_models = sampler.sample(nsamples=nsamples, save_hidden_state_trajectory=False)

--- a/examples/rnase-h-d10a/generate-figure.py
+++ b/examples/rnase-h-d10a/generate-figure.py
@@ -46,7 +46,7 @@ def run(nstates, nsamples):
 
     # Initialize BHMM, using MLHMM model as initial model.
     print "Initializing BHMM and running with "+str(nsamples)+" samples."
-    sampler = bhmm.BayesianHMMSampler(O, nstates, initial_model=mle)
+    sampler = bhmm.BHMM(O, nstates, initial_model=mle)
 
     # Sample models.
     bhmm_models = sampler.sample(nsamples=nsamples, save_hidden_state_trajectory=False)

--- a/examples/synthetic-three-state-model/generate-figure.py
+++ b/examples/synthetic-three-state-model/generate-figure.py
@@ -61,7 +61,7 @@ def run(nstates, nsamples):
 
     # Initialize BHMM with MLHMM model.
     print "Sampling models from BHMM..."
-    sampler = bhmm.BayesianHMMSampler(O, nstates, initial_model=mle)
+    sampler = bhmm.BHMM(O, nstates, initial_model=mle)
     bhmm_models = sampler.sample(nsamples=nsamples, save_hidden_state_trajectory=False)
 
     # Generate a sample saving a hidden state trajectory.


### PR DESCRIPTION
- bugfix: ensuring that the discrete HMM initialization provides a reversible transition matrix
- Added test using an initialization of a 3-state HMM
- bugfix: avoiding infinite recursion in **desc** and **str** of HMM subtypes due to inheritance from output model
