### PR TITLE
Get bhmm ready for pypi (deployment)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,20 @@ env:
 after_success:
   - echo "after_success"
   - bash -x devtools/ci/after_sucess.sh
+
+deploy:                                                                         
+  edge: true # testing bleeding edge git deployment code                        
+  provider: pypi                                                                
+  distributions: "sdist"                                                        
+  skip_cleanup: true                                                            
+# docs_dir is ignored by travis (despite the issue filed against this feature, maybe its not yet active?
+#  docs_dir: doc/build/html                                                     
+# TODO: security tokens are encrypted on repository base (reencrypt when moving repo to cmb organisation) 
+  user:                                                                         
+    secure: "Z6h333HK9R9b4vwYzk5N54IeMJ8vmd4V+vXRTLNnOCCqVkWcocWY9HBX2s9jk3TkSJbg9eL/EVzCv7HVGY1A80czNN160Vj3z5J51WEfHk4hhC7GDSXEU1CGRdp3j+79/WeaioOstq3y4Mxy6v1Afn3k7gAY7ui+yYbSEbRIG0A="
+  password:                                                                     
+    secure: "F3I26Mx0vbiIrSf/MsE8OGNV4xr82Wx4AWItHcXEq+pwBreNyCg/KVQInJ90lSh2RmvGAMmzw6rQ4EFaHYrFuAekilM/4tkRBGF/pSrEG7KSL2ysyoJIqTRncJCs1USyNYWodmXjRTQjLyJKoZufpNZ4u6Da1pVQDZqbsL0LtZo="
+  on:                                                                           
+    python: 2.7 # only upload docs and sdist for py27                           
+    tags: true                                                                  
+    branches: master 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ env:
 
   global:
 
-after_success:
-  - echo "after_success"
-  - bash -x devtools/ci/after_sucess.sh
+# TODO: no amazon s3 server to publish docs to
+#after_success:
+#  - echo "after_success"
+#  - bash -x devtools/ci/after_sucess.sh
 
 deploy:                                                                         
   edge: true # testing bleeding edge git deployment code                        

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include bhmm *.c *.h *.pyx

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,8 @@ CLASSIFIERS = """\
 Development Status :: 3 - Alpha
 Intended Audience :: Science/Research
 Intended Audience :: Developers
-License :: OSI Approved :: Lesser GNU Public License (LGPL)
+License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
 Programming Language :: Python
-Programming Language :: Python :: 3
 Topic :: Scientific/Engineering :: Bio-Informatics
 Topic :: Scientific/Engineering :: Chemistry
 Operating System :: Microsoft :: Windows

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
-"""
-BHMM: A toolkit for Bayesian hidden Markov model analysis of single-molecule trajectories.
+""" BHMM: A toolkit for Bayesian hidden Markov model analysis of single-molecule trajectories.
 
+This project provides tools for estimating the number of metastable states, rate
+constants between the states, equilibrium populations, distributions
+characterizing the states, and distributions of these quantities from
+single-molecule data. This data could be FRET data, single-molecule pulling
+data, or any data where one or more observables are recorded as a function of
+time. A Hidden Markov Model (HMM) is used to interpret the observed dynamics,
+and a distribution of models that fit the data is sampled using Bayesian
+inference techniques and Markov chain Monte Carlo (MCMC), allowing for both the
+characterization of uncertainties in the model and modeling of the expected
+information gain by new experiments.
 """
+
 from __future__ import print_function
 import os
 import sys


### PR DESCRIPTION
This change to travis enables to automatically push a source archive to pypi, once a project owner pushes a new tag (release) to git. 

note: this is not functional, since the security tokens are encrypted via a repository specific private key and only the owners are able to encrypt these.

What you have to do, to make this work is the following:
1. create a pypi account for bhmm (I really encourage to have this)
2. encrypt username and password according to this guide: http://docs.travis-ci.com/user/encryption-keys/
3. push releases and be happy.
